### PR TITLE
deploy/template: also tolerate node-role.kubernetes.io/control-plane taint

### DIFF
--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -41,6 +41,9 @@ spec:
           effect: NoSchedule
         - key: CriticalAddonsOnly
           operator: Exists
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
+          operator: Exists
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
           operator: Exists

--- a/deploy/template/deployment.yaml
+++ b/deploy/template/deployment.yaml
@@ -33,6 +33,9 @@ spec:
         - key: "node-role.kubernetes.io/master"
           effect: NoSchedule
           operator: Exists
+        - key: "node-role.kubernetes.io/control-plane"
+          effect: NoSchedule
+          operator: Exists
       containers:
       - image: equinix/cloud-provider-equinix-metal:RELEASE_TAG
         name: cloud-provider-equinix-metal


### PR DESCRIPTION
Those seem to be present on some Rancher clusters, instead of `node-role.kubernetes.io/master`. This will have the CCM tolerate that taint as well, so it can be scheduled on these nodes.