### PR TITLE
Remove-save-state-from-ci-yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,8 +54,8 @@ jobs:
     - id: go-cache-paths
       shell: bash
       run: |
-        echo "::set-output name=go-build::$(go env GOCACHE)"
-        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+        echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+        echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
     - name: Go Mod Cache
       uses: actions/cache@v3
       with:
@@ -104,7 +104,7 @@ jobs:
         [[ "$GITHUB_EVENT_NAME" == "pull_request" ]] && SHOULD_PUSH=false
         # Skip pushing if a pull request and branch is not main
         [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF_NAME" != "main" ]] && SHOULD_PUSH=false
-        echo "::set-output name=should-push::${SHOULD_PUSH}"
+        echo "should-push=${SHOULD_PUSH}" >> $GITHUB_OUTPUT
 
     - name: Log in to ghcr.io
       uses: docker/login-action@v2


### PR DESCRIPTION
Our CI is using deprecated functionality for saving outputs. We need to convert to using environment files or our workflows will stop working later this year.

Details are here: 
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

Signed-off-by: Chris Privitere <23177737+cprivitere@users.noreply.github.com>