### PR TITLE
Update Readme to suggest v3.6.2 for the CCM deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ dist/*
 vendor/
 hacks/
 tmp/
-
+.idea

--- a/README.md
+++ b/README.md
@@ -177,8 +177,9 @@ metal-cloud-config   Opaque                                1         2m
 
 To apply the CCM itself, select your release and apply the manifest:
 
+Example:
 ```
-RELEASE=v2.0.0
+RELEASE=v3.6.2
 kubectl apply -f https://github.com/equinix/cloud-provider-equinix-metal/releases/download/${RELEASE}/deployment.yaml
 ```
 


### PR DESCRIPTION
Updates readme to direct to deploy latest CCM version

[Issue](https://github.com/kubernetes-sigs/cloud-provider-equinix-metal/issues/436)