### PR TITLE
refactor: cleanup of cpem

### DIFF
--- a/deploy/template/deployment.yaml
+++ b/deploy/template/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       dnsPolicy: Default
       hostNetwork: true
       priorityClassName: system-cluster-critical
-      serviceAccountName: cloud-controller-manager
+      serviceAccountName: cloud-provider-equinix-metal
       # set node affinity such that it will run only on nodes that have one of (logical OR)
       # the labels:
       #   kubernetes.io/role: master
@@ -28,53 +28,53 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/role
-                operator: In
-                values: [master]
-            - matchExpressions:
-              - key: node-role.kubernetes.io/control-plane
-                operator: Exists
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
+              - matchExpressions:
+                  - key: kubernetes.io/role
+                    operator: In
+                    values: [master]
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/master
+                    operator: Exists
       tolerations:
         # this taint is set by all kubelets running `--cloud-provider=external`
-        # so we should tolerate it to schedule the Equinix Metal ccm
+        # so we should tolerate it to schedule Cloud Provider Equinix Metal
         - key: "node.cloudprovider.kubernetes.io/uninitialized"
           value: "true"
-          effect: "NoSchedule"
+          effect: NoSchedule
+        # these tolerations are to have the daemonset runnable on control plane nodes
+        - key: "node-role.kubernetes.io/control-plane"
+          operator: Exists
+          effect: NoSchedule
+        - key: "node-role.kubernetes.io/master"
+          operator: Exists
+          effect: NoSchedule
         - key: "CriticalAddonsOnly"
           operator: "Exists"
-        # cloud controller manager should be able to run on masters
-        - key: "node-role.kubernetes.io/master"
-          effect: NoSchedule
-          operator: Exists
-        - key: "node-role.kubernetes.io/control-plane"
-          effect: NoSchedule
-          operator: Exists
-        # Needed to let CCM come up and assign the EIP
+        # Needed to let Cloud Provider Equinix Metal come up and assign the EIP
         - key: "node.kubernetes.io/not-ready"
           effect: NoSchedule
           operator: Exists
       containers:
-      - image: RELEASE_IMG
-        name: cloud-provider-equinix-metal
-        imagePullPolicy: Always
-        command:
-          - "./cloud-provider-equinix-metal"
-          - "--cloud-provider=equinixmetal"
-          - "--leader-elect=true"
-          - "--authentication-skip-lookup=true"
-          - "--cloud-config=/etc/cloud-sa/cloud-sa.json"
-        resources:
-          requests:
-            cpu: 100m
-            memory: 50Mi
-        volumeMounts:
-          - name: cloud-sa-volume
-            readOnly: true
-            mountPath: "/etc/cloud-sa"
+        - image: RELEASE_IMG
+          name: cloud-provider-equinix-metal
+          imagePullPolicy: Always
+          command:
+            - "./cloud-provider-equinix-metal"
+            - "--cloud-provider=equinixmetal"
+            - "--leader-elect=true"
+            - "--authentication-skip-lookup=true"
+            - "--cloud-config=/etc/cloud-sa/cloud-sa.json"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 50Mi
+          volumeMounts:
+            - name: cloud-sa-volume
+              readOnly: true
+              mountPath: "/etc/cloud-sa"
       volumes:
         - name: cloud-sa-volume
           secret:
@@ -84,131 +84,129 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: cloud-controller-manager
+  name: cloud-provider-equinix-metal
   namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
-    rbac.authorization.kubernetes.io/autoupdate: "true"
-  name: system:cloud-controller-manager
+  name: cloud-provider-equinix-metal
 rules:
-- apiGroups:
-  # reason: so ccm can read the information about the kube-system namespace
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
-- apiGroups:
-  # reason: so ccm can monitor and update endpoints, used for control plane loadbalancer
-  - ""
-  resources:
-  - endpoints
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-  - update
-  - patch
-- apiGroups:
-  # reason: so ccm can read and update nodes and annotations
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - '*'
-- apiGroups:
-  # reason: so ccm can update the status of nodes
-  - ""
-  resources:
-  - nodes/status
-  verbs:
-  - patch
-- apiGroups:
-  # reason: so ccm can manage services for loadbalancer
-  - ""
-  resources:
-  - services
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
-  - create
-- apiGroups:
-  # reason: so ccm can update the status of services for loadbalancer
-  - ""
-  resources:
-  - services/status
-  verbs:
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  # reason: so ccm can read and update configmap for MetalLB <= 0.12.1
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-  - update
-  - patch
-- apiGroups:
-  # reason: so ccm can read and update events
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-  - update
-  - patch
-- apiGroups:
-  # reason: so ccm can use leases
-  - "coordination.k8s.io"
-  resources:
-  - leases
-  verbs:
-  - create
-  - get
-  - list
-  - watch
-  - update
-  - patch
-- apiGroups:
-  # reason: so ccm can manage CRDs for MetalLB v0.13.2+
-  - metallb.io
-  resources:
-  - ipaddresspools
-  - bgppeers
-  - bgpadvertisements
-  verbs:
-  - get
-  - list
-  - create
-  - update
-  - patch
-  - delete
+  - apiGroups:
+      # reason: so ccm can read the information about the kube-system namespace
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      # reason: so ccm can monitor and update endpoints, used for control plane loadbalancer
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
+  - apiGroups:
+      # reason: so ccm can read and update nodes and annotations
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - "*"
+  - apiGroups:
+      # reason: so ccm can update the status of nodes
+      - ""
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+  - apiGroups:
+      # reason: so ccm can manage services for loadbalancer
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+      - create
+  - apiGroups:
+      # reason: so ccm can update the status of services for loadbalancer
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      # reason: so ccm can read and update configmap for MetalLB <= 0.12.1
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
+  - apiGroups:
+      # reason: so ccm can read and update events
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
+  - apiGroups:
+      # reason: so ccm can use leases
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
+  - apiGroups:
+      # reason: so ccm can manage CRDs for MetalLB v0.13.2+
+      - metallb.io
+    resources:
+      - ipaddresspools
+      - bgppeers
+      - bgpadvertisements
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - patch
+      - delete
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: system:cloud-controller-manager
+  name: cloud-provider-equinix-metal
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:cloud-controller-manager
+  name: cloud-provider-equinix-metal
 subjects:
-- kind: ServiceAccount
-  name: cloud-controller-manager
-  namespace: kube-system
+  - kind: ServiceAccount
+    name: cloud-provider-equinix-metal
+    namespace: kube-system

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/packethost/packet-api-server v0.0.0-20230223042617-bc7d1539adbb
 	github.com/packethost/packngo v0.30.0
 	github.com/pallinder/go-randomdata v1.2.0
-	github.com/spf13/pflag v1.0.5
 	go.universe.tf/metallb v0.13.7
 	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
 	k8s.io/api v0.26.4
@@ -41,6 +40,7 @@ require (
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-logr/zapr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
 	github.com/go-openapi/swag v0.19.14 // indirect
@@ -71,6 +71,7 @@ require (
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/spf13/cobra v1.6.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.5 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,7 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/antlr/antlr4/runtime/Go/antlr v1.4.10 h1:yL7+Jz0jTC6yykIK/Wh74gnTJnrGr5AyrNMXuA0gves=
 github.com/antlr/antlr4/runtime/Go/antlr v1.4.10/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
+github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -133,6 +134,7 @@ github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbV
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-logr/zapr v1.2.3 h1:a9vnzlIBPQBBkeaR9IuMUfmVOrQlkoC4YfPoFkX3T7A=
+github.com/go-logr/zapr v1.2.3/go.mod h1:eIauM6P8qSvTw5o2ez6UEAfGjQKrxQTl5EoK+Qa2oG4=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonpointer v0.19.5 h1:gZr+CIYByUqjcgeLXnQu2gHYQC9o73G2XUeOFYEICuY=
 github.com/go-openapi/jsonpointer v0.19.5/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
@@ -405,11 +407,13 @@ go.opentelemetry.io/proto/otlp v0.19.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/multierr v1.7.0 h1:zaiO/rmgFjbmCXdSYJWQcdvOCsthmdaHfr3Gm2Kx4Ec=
 go.uber.org/multierr v1.7.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
+go.uber.org/zap v1.19.0/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=
 go.uber.org/zap v1.24.0 h1:FiJd5l1UOLj0wCgbSE0rwwXHzEdAZS6hiiSnxJN/D60=
 go.uber.org/zap v1.24.0/go.mod h1:2kMP+WWQ8aoFoedH3T2sq6iJ2yDWpHbP0f6MQbS9Gkg=
 go.universe.tf/metallb v0.13.7 h1:K/FS/ecpE/a0l5di8ZbFAXB7UP37S8vnrdLGnleiVGk=
@@ -596,6 +600,7 @@ golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191108193012-7d206e10da11/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191113191852-77e3bb0ad9e7/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=


### PR DESCRIPTION
Refactor of the main.go to be more in line with upstream examples.

Reference examples:
https://github.com/kubernetes/cloud-provider/blob/master/sample/basic_main.go
https://github.com/kubernetes/kubernetes/blob/master/cmd/cloud-controller-manager/main.go

- remove unnecessary random seeding
- register json logging library
- rename opts to ccmOptions like upstream
- update some comments
- remove no longer necessary pflag as well as flag normalization
- remove no longer necessary log init lines
- Use "cloud-provider-equinix-metal" for RBAC naming
