### PR TITLE
fix: return a valid LoadBalancerStatus for BGP-based load balancers

### DIFF
--- a/metal/loadbalancers.go
+++ b/metal/loadbalancers.go
@@ -126,7 +126,6 @@ func (l *loadBalancers) GetLoadBalancer(ctx context.Context, clusterName string,
 	clsTag := clusterTag(l.clusterID)
 	svcIP := service.Spec.LoadBalancerIP
 
-	var svcIPCidr string
 	if l.usesBGP {
 		// get IP address reservations and check if they any exists for this svc
 		ips, _, err := l.client.ProjectIPs.List(l.project, &packngo.ListOptions{})
@@ -142,10 +141,9 @@ func (l *loadBalancers) GetLoadBalancer(ctx context.Context, clusterName string,
 		if ipReservation == nil {
 			return nil, false, nil
 		}
-		svcIPCidr = fmt.Sprintf("%s/%d", ipReservation.Address, ipReservation.CIDR)
 		return &v1.LoadBalancerStatus{
 			Ingress: []v1.LoadBalancerIngress{
-				{IP: svcIPCidr},
+				{IP: ipReservation.Address},
 			},
 		}, true, nil
 	} else {


### PR DESCRIPTION
While introducing Equinix Metal Load Balancer support in CPEM, we updated the `EnsureLoadBalancer` function to return the result of `GetLoadBalancer` so that the code to return a LoadBalancerStatus for existing load balancers is in one place.

As a result of that consolidation, we uncovered an inconsistency in the two calculations of LoadBalancerStatus: the one in EnsureLoadBalancer created an Ingress with the load balancer IP, but the one in GetLoadBalancer created an Ingress with the load balancer CIDR, which is not valid.

This updates the GetLoadBalancer implementation to match the valid code that was previously in EnsureLoadBalancer.