### PR TITLE
fix: hook the EMLB client up to our debug env var

### DIFF
--- a/metal/loadbalancers/emlb/infrastructure/manager.go
+++ b/metal/loadbalancers/emlb/infrastructure/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"reflect"
 
 	lbaas "github.com/equinix/cloud-provider-equinix-metal/internal/lbaas/v1"
@@ -34,6 +35,7 @@ type Manager struct {
 func NewManager(metalAPIKey, projectID, metro string) *Manager {
 	manager := &Manager{}
 	emlbConfig := lbaas.NewConfiguration()
+	emlbConfig.Debug = checkDebugEnabled()
 
 	manager.client = lbaas.NewAPIClient(emlbConfig)
 	manager.tokenExchanger = &TokenExchanger{
@@ -244,4 +246,9 @@ func (m *Manager) createOrigin(ctx context.Context, poolID, poolName string, num
 
 func getResourceName(loadBalancerName, resourceType string, number int32) string {
 	return fmt.Sprintf("%v-%v-%v", loadBalancerName, resourceType, number)
+}
+
+func checkDebugEnabled() bool {
+	_, legacyVarIsSet := os.LookupEnv("PACKNGO_DEBUG")
+	return legacyVarIsSet
 }


### PR DESCRIPTION
This updates the Equinix Metal Load Balancer integration to enable HTTP client debug logs when the `PACKNGO_DEBUG` environment variable is set.  In the future we may introduce other ways of enabling debug logs for the provider, but this change enables users to debug the EMLB parts of the provider using the same approach they use to debug the rest of the provider.