### PR TITLE
:bug: avoid panic by using GetMd5() instead of Md5.Get

### DIFF
--- a/metal/bgp.go
+++ b/metal/bgp.go
@@ -52,7 +52,7 @@ func (b *bgp) enableBGP() error {
 	// - bgpConfig struct does not have Status=="disabled"
 	if err == nil && bgpConfig != nil && bgpConfig.GetId() != "" && bgpConfig.GetStatus() != metal.BGPCONFIGSTATUS_DISABLED {
 		b.localASN = int(bgpConfig.GetAsn())
-		b.bgpPass = *bgpConfig.Md5.Get()
+		b.bgpPass = bgpConfig.GetMd5()
 		return nil
 	}
 


### PR DESCRIPTION
This PR fixes a panic caused by using bgpConfig.Md5.Get() in situations where the MD5 hash isn't set. We use GetMd5() instead which checks for this for us.