### PR TITLE
fix: enable equinix-sdk-go debugging when PACKNGO_DEBUG env var is set

### DIFF
--- a/metal/cloud.go
+++ b/metal/cloud.go
@@ -3,6 +3,7 @@ package metal
 import (
 	"fmt"
 	"io"
+	"os"
 
 	metal "github.com/equinix/equinix-sdk-go/services/metalv1"
 	cloudprovider "k8s.io/cloud-provider"
@@ -61,6 +62,7 @@ func init() {
 		configuration := metal.NewConfiguration()
 		configuration.AddDefaultHeader("X-Auth-Token", metalConfig.AuthToken)
 		configuration.UserAgent = fmt.Sprintf("cloud-provider-equinix-metal/%s %s", version.Get(), configuration.UserAgent)
+		configuration.Debug = checkDebugEnabled()
 		client := metal.NewAPIClient(configuration)
 		cloud, err := newCloud(metalConfig, client)
 		if err != nil {
@@ -151,4 +153,9 @@ func (c *cloud) ProviderName() string {
 func (c *cloud) HasClusterID() bool {
 	klog.V(5).Info("called HasClusterID")
 	return true
+}
+
+func checkDebugEnabled() bool {
+	_, legacyVarIsSet := os.LookupEnv("PACKNGO_DEBUG")
+	return legacyVarIsSet
 }


### PR DESCRIPTION
The old packngo SDK had built-in support for enabling debug logging if the `PACKNGO_DEBUG` environment variable was set to any value.  The generated equinix-sdk-go SDK requires explicitly enabling debug logging in consumer code, so when we switched from `packngo` to `equinix-sdk-go` we lost support for the `PACKNGO_DEBUG` environment variable.  This updates CPEM to enable debug logging for `equinix-sdk-go` if the old `PACKNGO_DEBUG` environment variable is set.

Fixes #517