### PR TITLE
fix: handle svc objects with empty annotations

### DIFF
--- a/metal/loadbalancers/emlb/emlb.go
+++ b/metal/loadbalancers/emlb/emlb.go
@@ -90,8 +90,15 @@ func (l *LB) reconcileService(ctx context.Context, svc *v1.Service, n []*v1.Node
 
 	patch := client.MergeFrom(svc.DeepCopy())
 
-	svc.Annotations[LoadBalancerIDAnnotation] = loadBalancer.GetId()
-	svc.Annotations["equinix.com/loadbalancerMetro"] = l.manager.GetMetro()
+	annotations := svc.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	annotations[LoadBalancerIDAnnotation] = loadBalancer.GetId()
+	annotations["equinix.com/loadbalancerMetro"] = l.manager.GetMetro()
+
+	svc.SetAnnotations(annotations)
 
 	return l.client.Patch(ctx, svc, patch)
 }


### PR DESCRIPTION
Check if svc objects have no annotations and create a map to avoid a nil pointer reference. Inspired by: https://github.com/kubernetes-sigs/cluster-api/blob/v1.7.3/util/annotations/helpers.go

Fixes: #477