### PR TITLE
chore(deps): Bump docker/metadata-action to v5

### DIFF
--- a/.github/actions/metadata/action.yaml
+++ b/.github/actions/metadata/action.yaml
@@ -39,7 +39,7 @@ runs:
       echo "images=${IMAGES}" >> $GITHUB_OUTPUT
   - name: Docker manager metadata
     id: meta
-    uses: docker/metadata-action@v4
+    uses: docker/metadata-action@v5
     with:
       images: ${{ steps.image-urls.outputs.images }}
       flavor: ${{ inputs.metadata_flavor }}


### PR DESCRIPTION
Bump the docker/metadata-action in our metadata action to v5.

We should refactor this repo's CI to be more like the cluster api provider packet CI. There is no reason to use this custom composite metadata action anymore.